### PR TITLE
fix: correct offset value in v4to nfs4.WriteFile call

### DIFF
--- a/cmd/nfs4/v4to/v4to.go
+++ b/cmd/nfs4/v4to/v4to.go
@@ -211,7 +211,7 @@ func transferFile(nfs4 *nfs4.NfsClient, srcfile string, targetfile string, turni
 	}
 
 	// Call the nfs4.WriteFile function with the correct arguments
-	_, err = nfs4.WriteFile(targetfile, true, uint64(fileSize), reader)
+	_, err = nfs4.WriteFile(targetfile, true, 0, reader)
 	if err != nil {
 		return fmt.Errorf("failed to create destination file: %w", err)
 	}


### PR DESCRIPTION
First of all, I want to thank you for this tool.

Thanks to it, it is possible to upload data to nfs storage within a gitlab pipeline job running in non-privileged runner/container.

However, when we used ncp v4to, each uploaded file was twice as large, with the first half of the data being zeros.

After a quick check of the code, I found that the size of the source file is sent as the offset parameter value to the [nfs4.WriteFile](https://github.com/kha7iq/ncp/blob/874dfe720e9bcb87925bbd38f9900b54c2c847ba/cmd/nfs4/v4to/v4to.go#L214) call, which causes the doubling of the size and the zeroes at the beginning, since it writes not from the beginning, but from the size of the file.

So I'm offering a fix right away and hoping a new version will be released.

(Yes, I can compile it myself, but I prefer to add official releases to docker images)